### PR TITLE
shorten trans call

### DIFF
--- a/ps_customersignin.php
+++ b/ps_customersignin.php
@@ -49,8 +49,8 @@ class Ps_CustomerSignIn extends Module implements WidgetInterface
 
         parent::__construct();
 
-        $this->displayName = $this->getTranslator()->trans('Customer "Sign in" link', [], 'Modules.Customersignin.Admin');
-        $this->description = $this->getTranslator()->trans('Make your customers feel at home on your store, invite them to sign in!', [], 'Modules.Customersignin.Admin');
+        $this->displayName = $this->trans('Customer "Sign in" link', [], 'Modules.Customersignin.Admin');
+        $this->description = $this->trans('Make your customers feel at home on your store, invite them to sign in!', [], 'Modules.Customersignin.Admin');
         $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
 
         $this->templateFile = 'module:ps_customersignin/ps_customersignin.tpl';
@@ -75,7 +75,7 @@ class Ps_CustomerSignIn extends Module implements WidgetInterface
         $logged = $this->context->customer->isLogged();
 
         if ($logged) {
-            $customerName = $this->getTranslator()->trans(
+            $customerName = $this->trans(
                 '%firstname% %lastname%',
                 [
                     '%firstname%' => $this->context->customer->firstname,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Module class has its own [trans](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L3363) function so we need to replace `getTranslator()->trans` by `trans` to keep consistency and briefness.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30193
| How to test?  | Nothing changes in module's behavior. Check the Module `trans` code in the above Description is the best way verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
